### PR TITLE
Adds @app alias to webpack configuration

### DIFF
--- a/src/webpack/webpack.config-distribution.js
+++ b/src/webpack/webpack.config-distribution.js
@@ -5,6 +5,7 @@ const projectPath = path.resolve(__dirname, '../../');
 
 module.exports = function (env) {
   const PROJECT_ROOT_PATH = env && env.DP_PROJECT_ROOT ? env.DP_PROJECT_ROOT : projectPath;
+  const PARENT_ROOT_PATH = path.resolve(PROJECT_ROOT_PATH, '../../..');
   const DEBUG = env && env.NODE_ENV === 'development';
 
   const buildManifest = new dpat.BuildManifest(
@@ -43,6 +44,7 @@ module.exports = function (env) {
           loader: 'babel-loader',
            include: [
               path.resolve(PROJECT_ROOT_PATH, 'src/main/javascript'),
+              path.resolve(PARENT_ROOT_PATH, 'src'),
               useCustomSettingsSrc ? path.resolve(PROJECT_ROOT_PATH, 'src/settings/javascript') : null,
            ].filter(x => !!x).map(path => fs.realpathSync(path)),
           options: babelOptions
@@ -111,7 +113,10 @@ module.exports = function (env) {
     ],
     resolve: {
       extensions: ['*', '.js', '.jsx', '.scss', '.css'],
-      modules: [ "node_modules", dpat.path("node_modules"), path.join(PROJECT_ROOT_PATH, "node_modules") ]
+      modules: [ "node_modules", dpat.path("node_modules"), path.join(PROJECT_ROOT_PATH, "node_modules") ],
+      alias: {
+          '@app': path.resolve(PARENT_ROOT_PATH, 'src')
+      }
     },
     resolveLoader: {
       modules: [ "node_modules", dpat.path("node_modules"), path.join(PROJECT_ROOT_PATH, "node_modules") ]


### PR DESCRIPTION
Not sure this is the best approach to the problem "installer source can not use imports from other source module" but it gets the job done.

Instead of writing this code to import from the main app:

```
import {Smth} from '../../main/javascript/Smth';
```

You write it like this:

```
import {Smth} from '@app/main/javascript/Smth';
```
The changes essentially turn the primary app into a separate module.